### PR TITLE
Update installer action environment to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     default: 'latest'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following warning while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.


<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
[BUG] Node.js 12 actions are deprecated #29

<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Update installer action environment to Node 16

Signed-off-by: Enes <ahmedenesturan@gmail.com>
